### PR TITLE
Refactor Critic Flow + Replace OpenAI with Ollama 

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,6 @@ from hat_manager import (
     clear_memory
 )
 
-import openai
 
 import os
 from dotenv import load_dotenv

--- a/app.py
+++ b/app.py
@@ -4,8 +4,11 @@ from chainlit.input_widget import TextInput, Select, Tags # Keep only one import
 from chainlit.element import Text # Explicit imports can be clearer
 from chainlit.action import Action # Explicit import
 import re
+from hat_templates import clone_hat_template
 
 from datetime import datetime
+
+from hat_templates import clone_hat_template  # import at top if not already
 
 from hat_manager import (
     list_hats,
@@ -86,16 +89,16 @@ async def wear_hat(hat_id: str):
                 f"🧢 Now wearing: `{hat.get('name', hat_id)}`\n\n"
                 f"To edit this Hat, you can:\n"
                 f"• Type `edit {hat_id}` then paste JSON\n"
-                f"• Click the **Edit This Hat** button below"
+                # f"• Click the **Edit This Hat** button below"
             ),
-            actions=[
-                Action(
-                    name="edit_hat_ui", # Matches the callback name
-                    label="📝 Edit This Hat (UI)",
-                    value="edit", # Value isn't strictly needed if using payload
-                    payload={"hat_id": hat_id} # Send hat_id to the callback
-                )
-            ]
+            # actions=[
+            #     Action(
+            #         name="edit_hat_ui", # Matches the callback name
+            #         label="📝 Edit This Hat (UI)",
+            #         value="edit", # Value isn't strictly needed if using payload
+            #         payload={"hat_id": hat_id} # Send hat_id to the callback
+            #     )
+            # ]
         ).send()
 
         # Don't necessarily need to show selector again immediately after wearing,
@@ -277,7 +280,72 @@ async def handle_message(message: cl.Message):
                 await cl.Message(content="```json\n" + json.dumps(current_hat, indent=2) + "\n```").send()
         else:
             await cl.Message(content="Usage: `edit <hat_id>`").send()
-            
+    elif content_lower.startswith("add qa to "):
+        parts = content.split(" ", 3)
+        if len(parts) < 4:
+            await cl.Message(content="❌ Usage: `add qa to <hat_id>`").send()
+            return
+
+        target_hat_id = parts[3].strip()
+        try:
+            target_hat = load_hat(target_hat_id)
+            team_id = target_hat.get("team_id")
+            if not team_id:
+                await cl.Message(content="❌ Hat is not part of a team. Add it to a team first.").send()
+                return
+
+            # Add QA loop settings
+            target_hat["qa_loop"] = True
+            target_hat["retry_limit"] = target_hat.get("retry_limit", 2)
+            critic_id = f"critic_{team_id}"
+            if "critics" not in target_hat or not isinstance(target_hat["critics"], list):
+                target_hat["critics"] = []
+
+            if critic_id not in target_hat["critics"]:  # 🔧 Add critic reference if missing
+                target_hat["critics"].append(critic_id)
+
+            save_hat(target_hat_id, normalize_hat(target_hat, team_id=team_id, flow_order=target_hat.get("flow_order", 1)))
+            await cl.Message(content=f"✅ QA loop enabled for `{target_hat_id}` with critic `{critic_id}`.").send()
+
+            # Add critic hat if not already in disk
+            if critic_id not in list_hats():
+                new_critic = clone_hat_template("critic", new_suffix=team_id, team_id=team_id, flow_order=99)
+                save_hat(new_critic["hat_id"], new_critic)
+                await cl.Message(content=f"🎩 Cloned and saved Critic Hat: `{new_critic['hat_id']}`").send()
+
+            await show_hat_sidebar()
+            await show_hat_selector()
+
+        except Exception as e:
+            await cl.Message(content=f"❌ Failed to add QA loop to `{target_hat_id}`: {e}").send() 
+    elif content_lower.startswith("remove critic from team "):
+        parts = content.split(" ", 4)
+        if len(parts) < 5:
+            await cl.Message(content="❌ Usage: `remove critic from team <team_id>`").send()
+            return
+
+        team_id = parts[4].strip()
+        try:
+            hats = list_hats_by_team(team_id)
+            critic_id = f"critic_{team_id}"
+            filtered_hats = [hat for hat in hats if hat["hat_id"] != critic_id]
+
+            if len(filtered_hats) == len(hats):
+                await cl.Message(content=f"⚠️ No critic found in team `{team_id}`.").send()
+            else:
+                path = f"./hats/{critic_id}.json"
+                if os.path.exists(path):
+                    os.remove(path)
+                    await cl.Message(content=f"🗑️ Removed Critic Hat `{critic_id}` from disk.").send()
+                else:
+                    await cl.Message(content=f"⚠️ Critic file `{critic_id}.json` not found.").send()
+
+            await show_hat_sidebar()
+            await show_hat_selector()
+
+        except Exception as e:
+            await cl.Message(content=f"❌ Failed to remove critic from team `{team_id}`: {e}").send()
+    
     elif content_lower.startswith("view memories"):
         parts = content.split(" ", 2)
         tag = parts[2].strip() if len(parts) > 2 else None
@@ -548,7 +616,6 @@ async def handle_message(message: cl.Message):
             return
 
         try:
-            from hat_templates import clone_hat_template  # import at top if not already
 
             new_hat = clone_hat_template(base_hat_id)
             await cl.Message(content=f"🎩 Cloned Hat `{base_hat_id}` ➔ `{new_hat['hat_id']}`\nYou can now `wear {new_hat['hat_id']}`.").send()

--- a/prompts.py
+++ b/prompts.py
@@ -6,7 +6,7 @@ import requests
 from datetime import datetime
 from dotenv import load_dotenv
 
-from hat_manager import build_hat_schema_prompt, load_hat, normalize_hat, search_memory, save_hat
+from hat_manager import build_hat_schema_prompt, ensure_schema_defaults, load_hat, normalize_hat, search_memory, save_hat
 import chainlit as cl
 
 load_dotenv()
@@ -63,7 +63,7 @@ def call_ollama_llm(prompt, model="llama3:8b", max_retries=3):
 
     raise Exception("Failed to get valid response from Ollama after retries.")
 
-
+##For use with Hat Generation
 def call_openai_llm(messages, model="gpt-3.5-turbo", temperature=0.7, max_tokens=1000):
     return client.chat.completions.create(
         model=model,
@@ -72,6 +72,15 @@ def call_openai_llm(messages, model="gpt-3.5-turbo", temperature=0.7, max_tokens
         max_tokens=max_tokens
     ).choices[0].message.content
 
+
+def openai_hat_generator(prompt):
+    system = build_hat_schema_prompt()
+    response = call_openai_llm([
+        {"role": "system", "content": system},
+        {"role": "user", "content": prompt}
+    ])
+    raw_hat = parse_llm_response_to_hat(response)
+    return ensure_schema_defaults(raw_hat)
 
 # -----------------------------
 # Application Logic

--- a/readme.md
+++ b/readme.md
@@ -207,7 +207,7 @@ MIT License — Open to extend and build upon.
 # 📈 NEXT STEPS:
 
 ### **UI:**
-- Form field freezes after first edit (Chainlit issue). Consider a separate service for modifying Hat metadata or continue JSON pasting.
+- Form field freezes after first edit (Chainlit issue). Consider a separate service for modifying Hat metadata or continue JSON pasting.( disbaled feature for now due to many changes in the hat schema during this hackathon period)
 - Build a simple calendar app to run specific agents at specific times with separate memory and context.
 
 ### **Memory Related:**
@@ -355,77 +355,3 @@ Here’s a concise step-by-step **guide** on how you integrated the **Critic Age
   - Adding the **Critic’s ID** to **`critics`**
 
 
-🧢 Hats Project: Mission Flow & QA System
-Our AI agent system is structured for clear mission-driven collaboration, with automatic quality control.
-
-✅ Here's how it works:
-
-🎯 Full Team Mission Flow
-mermaid
-Copy
-Edit
-flowchart TD
-  Start["🎯 Mission Start (Goal Given)"]
-  BuildTeam["🧢 Assemble Hats (Storyteller, Critic)"]
-  Storyteller["📜 Storyteller Generates Output"]
-  Critic["🧑‍⚖️ Critic Reviews Output"]
-  RevisionNeeded{❓ Revision Needed?}
-  Retry["🔄 Storyteller Retries Based on Feedback"]
-  Approve["✅ Critic Approves"]
-  Debrief["📜 Generate Mission Debrief"]
-  Awards["🏆 Agent Awards Ceremony"]
-  Reflections["🎤 Final Agent Reflections"]
-  Archive["🗂️ Save Mission Archive (with Reflections)"]
-  End["🏁 Mission Complete"]
-
-  Start --> BuildTeam
-  BuildTeam --> Storyteller
-  Storyteller --> Critic
-  Critic --> RevisionNeeded
-  RevisionNeeded -- Yes --> Retry
-  Retry --> Critic
-  RevisionNeeded -- No --> Approve
-  Approve --> Debrief
-  Debrief --> Awards
-  Awards --> Reflections
-  Reflections --> Archive
-  Archive --> End
-🔁 QA Loop Detail (Critic Review and Retry Mechanism)
-mermaid
-Copy
-Edit
-flowchart TD
-  StartQA["📜 Storyteller Output"]
-  CriticQA["🧑‍⚖️ Critic Reviews"]
-  RevisionNeededQA{❓ Revision Required?}
-  RetryQA["🔄 Storyteller Retries"]
-  ReCriticQA["🧑‍⚖️ Critic Re-Reviews"]
-  ApprovedQA["✅ Critic Approves"]
-  ManualReviewQA["👤 Manual User Review (Approve/Retry)"]
-
-  StartQA --> CriticQA
-  CriticQA --> RevisionNeededQA
-  RevisionNeededQA -- Yes --> RetryQA
-  RetryQA --> ReCriticQA
-  ReCriticQA --> RevisionNeededQA
-  RevisionNeededQA -- No --> ApprovedQA
-  RevisionNeededQA -- No Tag/Error --> ManualReviewQA
-🧠 Key System Features:
-🎯 Goal-driven Missions: Every team works toward a defined user goal.
-
-👥 Modular Agents (Hats): Each agent has a distinct role (Storyteller, Critic, Planner, etc).
-
-🧠 Autonomous QA: Critic agents enforce quality, retry agents if needed, or request human review.
-
-📜 Mission Logs: Full conversation history is saved.
-
-📜 Mission Debrief: LLM summarizes how the mission went.
-
-🏆 Agent Awards: MVP and Outstanding Contributor are recognized.
-
-🎤 Final Reflections: Each agent shares a short reflection on the mission.
-
-🗂️ Full Archive: Every mission (goal, log, debrief, agent reflections) is archived as a JSON file for history.
-
-✅ This structure creates an autonomous, explainable, memory-enabled AI team —
-perfect for future multi-mission orchestration.


### PR DESCRIPTION
### Pull Request: Refactor Critic Flow + Replace OpenAI with Ollama (Planned)

---

**Summary:**
This PR introduces a set of changes centered around improving the handling of critic agents in the Hat orchestration system, along with laying the groundwork for switching from OpenAI to a local model provider (e.g., Ollama).

---

### ✅ Changes Introduced

#### 1. **Critic Flow Rework**
- Introduced logic to **exclude QA-only critics** (critics without a `flow_order`) from `run_team_flow()`.
  ```python
  team_hats = [
    hat for hat in list_hats_by_team(team_id)
    if not (hat.get("role") == "critic" and hat.get("flow_order") in [None, "", 0])
  ]
  ```
- Mid- and end-flow critics **with valid `flow_order`** are allowed in team pipeline execution.
- QA critics (used dynamically with `qa_loop`) are attached per-agent and handled separately.
- When a critic returns `#APPROVED` or `#REVISION_REQUIRED`, the system pauses for user approval and updates mission state accordingly.

#### 2. **Fallback for Empty Vector Stores**
- Chroma `search_memory()` now includes an exception guard:
  ```python
  try:
      results = collection.query(...)
  except Exception as e:
      return []
  ```
  Prevents app crash when critics (or other hats) are queried without initialized embeddings.

#### 3. **Critic Flow Behavior Clarification**
- Only **one QA critic** is expected per agent (`hat['critics'][0]`)
- If QA critic returns `#APPROVED`, the system stores state and pauses for user input (`approve` or `retry`).
- Critic at end of flow **does not** pause for feedback — improvement needed.

---

### ⚠️ Issues Identified (Planned Fixes)

#### 1. **Final Critics Bypass Approval Prompt**
- When the last hat in a team is a critic (with flow_order), the approval prompt is skipped.
- Proposed fix: unify `#APPROVED` handling regardless of origin (QA loop or end-of-flow).

#### 2. **User Approval/Retry Flow Duplication**
- Approval logic is split across `run_team_flow` and `handle_qa_loop`.
- Needs centralization to avoid redundant session flags.

#### 3. **Inconsistent `mission_success` Flag Propagation**
- Mid-critic approvals set `mission_success`, but if the final critic requests revision, the mission may still say SUCCESS.
- Fix should treat the **final critic tag** as authoritative.

---

### 🧠 Future Plans

- [ ] **Refactor approval flow** to centralize `awaiting_user_approval` logic and unify `#APPROVED` behavior.
- [ ] **Add `strict_mode` flag** for critics to block completion on `#REVISION_REQUIRED` even in final step.
- [ ] **Replace `generate_openai_response` with `generate_ollama_response`** via dynamic backend routing (OpenAI/Ollama).
- [ ] **Add retry logic + feedback injection** as standard for critic loops using `generate_openai_response_with_system`.
- [ ] **Add memory seeding** to avoid Chroma errors during cold starts (e.g., `"System initialized."`).

---

### 📂 Files Modified
- `flow.py`
- `app.py`
- `hat_manager.py`
- `prompts.py`
- `utils.py` (for memory formatting and merge_tags)

---

### 🚀 Outcome
This sets the foundation for robust team QA review loops, supports critic chaining, and prepares for a local LLM swap while hardening flow logic and memory safety.

---

cc: @team-hats-core

